### PR TITLE
fix: fix cspell.cmd wrapper on windows

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,9 +28,9 @@ chmod +x ${PREFIX}/bin/cspell-esm
 
 # Create batch wrapper
 tee ${PREFIX}/bin/cspell.cmd << EOF
-call %CONDA_PREFIX%\bin\node %CONDA_PREFIX%\lib\node_modules\cspell\bin.mjs %*
+call %CONDA_PREFIX%\node %CONDA_PREFIX%\lib\node_modules\cspell\bin.mjs %*
 EOF
 
 tee ${PREFIX}/bin/cspell-esm.cmd << EOF
-call %CONDA_PREFIX%\bin\node %CONDA_PREFIX%\lib\node_modules\cspell\bin.mjs %*
+call %CONDA_PREFIX%\node %CONDA_PREFIX%\lib\node_modules\cspell\bin.mjs %*
 EOF

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 55fb0a6b22adb900674cb01728bff1ad85ec3a60235471fac8d6b1d41655ff64
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

closing https://github.com/conda-forge/cspell-feedstock/issues/37
<!--
Please add any other relevant info below:
-->
